### PR TITLE
fix(binding): add extrasProducer value to viewModelDelegate initialization

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("com.google.android.material:material:1.6.1")
     implementation("androidx.fragment:fragment-ktx:1.5.3")
+    implementation("androidx.activity:activity-ktx:1.6.0")
     implementation("androidx.recyclerview:recyclerview:1.2.1")
 
     implementation("androidx.compose.runtime:runtime:${Versions.compose}")

--- a/databinding/src/main/java/de/trbnb/mvvmbase/databinding/MvvmBindingActivity.kt
+++ b/databinding/src/main/java/de/trbnb/mvvmbase/databinding/MvvmBindingActivity.kt
@@ -34,7 +34,8 @@ abstract class MvvmBindingActivity<VM, B>(@LayoutRes override val layoutId: Int)
     override val viewModelDelegate: Lazy<VM> = ViewModelLazy(
         viewModelClass = viewModelClass.kotlin,
         storeProducer = { viewModelStore },
-        factoryProducer = { defaultViewModelProviderFactory }
+        factoryProducer = { defaultViewModelProviderFactory },
+        extrasProducer = { defaultViewModelCreationExtras }
     )
 
     @Suppress("UNCHECKED_CAST")
@@ -88,5 +89,6 @@ abstract class MvvmBindingActivity<VM, B>(@LayoutRes override val layoutId: Int)
     }
 
     @Suppress("EmptyFunctionBlock")
-    override fun onEvent(event: Event) { }
+    override fun onEvent(event: Event) {
+    }
 }

--- a/databinding/src/main/java/de/trbnb/mvvmbase/databinding/MvvmBindingFragment.kt
+++ b/databinding/src/main/java/de/trbnb/mvvmbase/databinding/MvvmBindingFragment.kt
@@ -35,7 +35,8 @@ abstract class MvvmBindingFragment<VM, B>(@LayoutRes override val layoutId: Int)
     override val viewModelDelegate: Lazy<VM> = ViewModelLazy(
         viewModelClass = viewModelClass.kotlin,
         storeProducer = { viewModelStore },
-        factoryProducer = { defaultViewModelProviderFactory }
+        factoryProducer = { defaultViewModelProviderFactory },
+        extrasProducer = { defaultViewModelCreationExtras }
     )
 
     private val mainHandler by lazy { Handler(Looper.getMainLooper()) }
@@ -73,7 +74,7 @@ abstract class MvvmBindingFragment<VM, B>(@LayoutRes override val layoutId: Int)
         onViewModelLoaded(viewModel)
     }
 
-    protected open fun onBindingCreated(binding: B) { }
+    protected open fun onBindingCreated(binding: B) {}
 
     /**
      * Creates a new [ViewDataBinding].


### PR DESCRIPTION
`extrasProducer` value added to the initialization of the `viewModelDelegate` in `MvvmBindingActivity` and `MvvmBindingFragment`.